### PR TITLE
Fix -Wc++11-narrowing error @ time_tracker.cpp:17

### DIFF
--- a/src/eventdispatcherlibuv_p.h
+++ b/src/eventdispatcherlibuv_p.h
@@ -111,7 +111,7 @@ public:
 private:
     void cleanTimerFromObject(int timerId, void *object);
     struct TimerInfo {
-        unsigned long lastFired;
+        uint64_t lastFired;
         int interval;
         void *object;
     };


### PR DESCRIPTION
This commit corrects a C++11 narrowing error when sizeof(unsigned long) < sizeof(uint64_t).

For example:
```
qt-event-dispatcher-libuv/src/eventdispatcherlibuv/time_tracker.cpp:17:28: error: non-constant-expression cannot be narrowed from type 'unsigned long long' to 'unsigned long' in initializer list [-Wc++11-narrowing]
    timerInfos[timerId] = {api->uv_hrtime() / 1000000, interval, object};
```