### PR TITLE
Add partial Windows support

### DIFF
--- a/src/eventdispatcherlibuv.cpp
+++ b/src/eventdispatcherlibuv.cpp
@@ -1,7 +1,11 @@
 #include "eventdispatcherlibuv.h"
+
 #include <QCoreApplication>
 #include <QSocketNotifier>
-
+#ifdef Q_OS_WIN
+#include <cassert>
+#include <QWinEventNotifier>
+#endif
 
 #include "uv.h"
 #include <QDebug>
@@ -89,6 +93,9 @@ bool EventDispatcherLibUv::processEvents(QEventLoop::ProcessEventsFlags flags)
     emit aboutToBlock();
 
     int leftHandles = uv_run(uv_default_loop(), UV_RUN_ONCE);
+#ifdef Q_OS_WIN
+    activateEventNotifiers();
+#endif
     if (!leftHandles) {
         if (osEventDispatcher) {
             osEventDispatcher->processEvents(flags & ~QEventLoop::EventLoopExec | QEventLoop::WaitForMoreEvents);
@@ -156,6 +163,91 @@ int EventDispatcherLibUv::remainingTime(int timerId)
 {
     return timerTracker->remainingTime(timerId);
 }
+
+#ifdef Q_OS_WIN
+void EventDispatcherLibUv::activateEventNotifiers() {
+    std::vector<WinEventNotifierInfo*> queue;
+    {
+        std::lock_guard<std::mutex> lock(winEventActQueueMutex);
+        winEventActQueue.swap(queue);
+    }
+    for (auto* weni : queue) {
+        QEvent event(QEvent::WinEventAct);
+        QCoreApplication::sendEvent(weni->notifier, &event);
+    }
+}
+
+void EventDispatcherLibUv::queueEventNotifierActivation(WinEventNotifierInfo* weni)
+{
+    {
+        std::lock_guard<std::mutex> lock(winEventActQueueMutex);
+        winEventActQueue.push_back(weni);
+    }
+    asyncChannel->send();
+}
+
+void EventDispatcherLibUv::queueEventNotifierActivation(PVOID context, BOOLEAN timedOut) {
+    assert(!timedOut);
+    auto* weni = static_cast<WinEventNotifierInfo*>(context);
+    weni->dispatcher->queueEventNotifierActivation(weni);
+}
+
+bool EventDispatcherLibUv::registerEventNotifier(QWinEventNotifier *notifier)
+{
+    if (!notifier) {
+        qWarning("EventDispatcherLibUv: Null event notifier");
+        return false;
+    }
+    if (notifier->thread() != thread() || thread() != QThread::currentThread()) {
+        qWarning("EventDispatcherLibUv: Event notifiers cannot be enabled from another thread");
+        return false;
+    }
+
+    for (const auto& weni : winEventNotifierList) {
+        if (weni->notifier == notifier)
+            return true;
+    }
+
+    auto weni = std::unique_ptr<WinEventNotifierInfo>(new WinEventNotifierInfo(this, notifier));
+    if (!RegisterWaitForSingleObject(&weni->waitHandle, notifier->handle(), queueEventNotifierActivation, weni.get(), INFINITE, WT_EXECUTEINWAITTHREAD)) {
+        qWarning("EventDispatcherLibUv: RegisterWaitForSingleObject failed");
+        return false;
+    }
+    if (winEventNotifierList.empty())
+        asyncChannel->ref();
+    winEventNotifierList.push_back(std::move(weni));
+    return true;
+}
+
+void EventDispatcherLibUv::unregisterEventNotifier(QWinEventNotifier *notifier)
+{
+    if (!notifier) {
+        qWarning("EventDispatcherLibUv: Null event notifier");
+        return;
+    }
+    if (notifier->thread() != thread() || thread() != QThread::currentThread()) {
+        qWarning("EventDispatcherLibUv: Event notifiers cannot be disabled from another thread");
+        return;
+    }
+
+    for (auto I = winEventNotifierList.begin(), E = winEventNotifierList.end(); I != E; ++I) {
+        const auto& weni = *I;
+        if (weni->notifier == notifier) {
+            BOOL res = UnregisterWaitEx(weni->waitHandle, INVALID_HANDLE_VALUE);
+            assert(res); (void)res;
+            // Remove any pending activations for the notifier being unregistered.
+            {
+                std::lock_guard<std::mutex> lock(winEventActQueueMutex);
+                winEventActQueue.erase(std::remove(winEventActQueue.begin(), winEventActQueue.end(), weni.get()), winEventActQueue.end());
+            }
+            winEventNotifierList.erase(I);
+            if (winEventNotifierList.empty())
+                asyncChannel->unref();
+            return;
+        }
+    }
+}
+#endif
 
 void EventDispatcherLibUv::startingUp() {
     auto pi = QGuiApplicationPrivate::platformIntegration();

--- a/src/eventdispatcherlibuv/async_channel.cpp
+++ b/src/eventdispatcherlibuv/async_channel.cpp
@@ -17,17 +17,25 @@ EventDispatcherLibUvAsyncChannel::~EventDispatcherLibUvAsyncChannel()
 {
     api->uv_close((uv_handle_t *)handle, &uv_close_asyncHandle);
 }
+
+void EventDispatcherLibUvAsyncChannel::ref()
+{
+    api->uv_ref((uv_handle_t*)handle);
+}
+
+void EventDispatcherLibUvAsyncChannel::unref()
+{
+    api->uv_unref((uv_handle_t*)handle);
+}
+
 void EventDispatcherLibUvAsyncChannel::send()
 {
     api->uv_async_send(handle);
 }
 
-
-
 void uv_close_asyncHandle(uv_handle_t* handle)
 {
     delete (uv_async_t *)handle;
 }
-
 
 }

--- a/src/eventdispatcherlibuv/libuv_api.cpp
+++ b/src/eventdispatcherlibuv/libuv_api.cpp
@@ -52,10 +52,14 @@ int LibuvApi::uv_async_send(uv_async_t* async)
     return ::uv_async_send(async);
 }
 
+void LibuvApi::uv_ref(uv_handle_t* handle)
+{
+    ::uv_ref(handle);
+}
+
 void LibuvApi::uv_unref(uv_handle_t* handle)
 {
     ::uv_unref(handle);
 }
-
 
 }

--- a/src/eventdispatcherlibuv_p.h
+++ b/src/eventdispatcherlibuv_p.h
@@ -49,6 +49,7 @@ struct LibuvApi {
     virtual int uv_async_init(uv_loop_t*, uv_async_t* async, uv_async_cb async_cb);
     virtual int uv_async_send(uv_async_t* async);
 
+    virtual void uv_ref(uv_handle_t* handle);
     virtual void uv_unref(uv_handle_t* handle);
 };
 
@@ -59,6 +60,8 @@ class EventDispatcherLibUvAsyncChannel {
 public:
     EventDispatcherLibUvAsyncChannel(LibuvApi *api = nullptr);
     virtual ~EventDispatcherLibUvAsyncChannel();
+    void ref();
+    void unref();
     void send();
 private:
     std::unique_ptr<LibuvApi> api;


### PR DESCRIPTION
On Windows event dispatchers must additionally implement functions
registerEventNotifier, and unregisterEventNotifier.

To finish Windows support, more changes are needed: EventDispatcherLibUv itself must derive from QEventDispatcherWin32. This is because there is code in Qt that looks like:
```
QEventDispatcherWin32 *q = qobject_cast<QEventDispatcherWin32 *>(QAbstractEventDispatcher::instance())
```