### PR TITLE
Issue #10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,12 @@
 project(qt-event-dispatcher-libuv)
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-add_definitions(
-  -DNOMINMAX
-  -DWIN32_LEAN_AND_MEAN
-)
+if(MSVC)
+  add_definitions(
+    -DNOMINMAX
+    -DWIN32_LEAN_AND_MEAN
+  )
+endif()
 
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 project(qt-event-dispatcher-libuv)
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
+add_definitions(
+  -DNOMINMAX
+  -DWIN32_LEAN_AND_MEAN
+)
+
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"


### PR DESCRIPTION
Fix build under Windows:
    - wrong include order of windows.h/winsock2.h.
    - disable definition of min/max macros in windows.h.
